### PR TITLE
Add trait images to affinity page

### DIFF
--- a/src/pages/Affinities.tsx
+++ b/src/pages/Affinities.tsx
@@ -94,6 +94,7 @@ const Affinities = observer((): JSX.Element => {
               return (
                 <Paper key={item} className={classes.card}>
                   <Typography variant="body1">{traitMap[item]}</Typography>
+                  <img src={"/assets/traits/" + item + ".png"} />
                 </Paper>
               );
             })}

--- a/src/pages/Affinities.tsx
+++ b/src/pages/Affinities.tsx
@@ -94,7 +94,7 @@ const Affinities = observer((): JSX.Element => {
               return (
                 <Paper key={item} className={classes.card}>
                   <Typography variant="body1">{traitMap[item]}</Typography>
-                  <img src={"/assets/traits/" + item + ".png"} />
+                  <img src={'/assets/traits/' + item + '.png'} />
                 </Paper>
               );
             })}


### PR DESCRIPTION
Probably not the best syntax but adding this as a way to view all the trait images when browsing affinity groups. Could be helpful in naming affinity groups